### PR TITLE
fix: don't allow two builds to run in parallel

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,9 +14,12 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: maven-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Cancel the existing build