### PR TITLE
feat: add dryRun field to spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ kind: KafkaPodAutoscaler
 metadata:
   name: myautoscaler
 spec:
+  dryRun: false # set true to see what the autoscaler _would_ do
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -45,4 +46,3 @@ spec:
 This repository uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) to generate a changelog and semver-based versions for every push to the `main` branch.
 
 Open a PR with your proposed changes, and your commits will be validated against the conventions
-

--- a/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
+++ b/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
@@ -29,6 +29,9 @@ spec:
               - scaleTargetRef
               - triggers
             properties:
+              dryRun:
+                type: boolean
+                default: false
               scaleTargetRef:
                 type: object
                 required:

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/KafkaPodAutoscalerReconciler.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/KafkaPodAutoscalerReconciler.java
@@ -23,11 +23,9 @@ import com.brandwatch.kafka_pod_autoscaler.triggers.TriggerResult;
 @Slf4j
 @ControllerConfiguration
 public class KafkaPodAutoscalerReconciler implements Reconciler<KafkaPodAutoscaler> {
-    private final boolean doScale;
     private final PartitionCountFetcher partitionCountFetcher;
 
-    public KafkaPodAutoscalerReconciler(boolean doScale, PartitionCountFetcher partitionCountFetcher) {
-        this.doScale = doScale;
+    public KafkaPodAutoscalerReconciler(PartitionCountFetcher partitionCountFetcher) {
         this.partitionCountFetcher = partitionCountFetcher;
     }
 
@@ -66,7 +64,7 @@ public class KafkaPodAutoscalerReconciler implements Reconciler<KafkaPodAutoscal
         var bestReplicaCount = fitReplicaCount(idealReplicaCount, partitionCount);
 
         if (currentReplicaCount != bestReplicaCount) {
-            if (doScale) {
+            if (!kafkaPodAutoscaler.getSpec().getDryRun()) {
                 resource.scale(bestReplicaCount);
             } else {
                 logger.info("Scaling deployment {} to {} replicas", targetName, bestReplicaCount);

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/Main.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/Main.java
@@ -15,7 +15,7 @@ public class Main {
         var client = new KubernetesClientBuilder().build();
         Operator operator = new Operator(client, c -> c.withLeaderElectionConfiguration(leaderElectionConfiguration));
 
-        operator.register(new KafkaPodAutoscalerReconciler(true, new PartitionCountFetcher()));
+        operator.register(new KafkaPodAutoscalerReconciler(new PartitionCountFetcher()));
         operator.start();
     }
 }

--- a/src/test/java/com/brandwatch/kafka_pod_autoscaler/KafkaPodAutoscalerReconcilerTest.java
+++ b/src/test/java/com/brandwatch/kafka_pod_autoscaler/KafkaPodAutoscalerReconcilerTest.java
@@ -50,7 +50,7 @@ public class KafkaPodAutoscalerReconcilerTest {
 
     @BeforeEach
     public void beforeEach() {
-        reconciler = new KafkaPodAutoscalerReconciler(true, partitionCountFetcher);
+        reconciler = new KafkaPodAutoscalerReconciler(partitionCountFetcher);
 
         when(mockContext.getClient()).thenReturn(client);
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
This should be useful for seeing what a scaler _would_ do without actually scaling anything

It replaces the doScale flag on the Reconciler constructor, which we were always setting to true. This way also allows the config to be set on a per-autoscaler basis