### PR TITLE
fix: tighten cluster role definition

### DIFF
--- a/kustomize/clusterrole.yaml
+++ b/kustomize/clusterrole.yaml
@@ -9,7 +9,7 @@ rules:
     resources:
       - customresourcedefinitions
     verbs:
-      - '*'
+      - get
   - apiGroups:
       - "com.brandwatch"
     resources:
@@ -26,12 +26,14 @@ rules:
   - apiGroups:
       - '*'
     resources:
+      - pods
       - deployments
       - statefulsets
       - cronjobs
       - daemonsets
     verbs:
-      - '*'
+      - get
+      - list
   - apiGroups:
       - '*'
     resources:


### PR DESCRIPTION
The service didn't need all the permissions it was being given