### PR TITLE
fix: cache kafka AdminClients in KafkaTriggerProcessor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
       <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>3.1.5</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service-annotations</artifactId>
       <version>${auto-service.version}</version>


### PR DESCRIPTION
Otherwise the logs get noisy whenever we need to spin one up