### PR TITLE
fix: shared AdminClient cache between fetcher and TriggerProcessor

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/PartitionCountFetcher.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/PartitionCountFetcher.java
@@ -1,23 +1,20 @@
 package com.brandwatch.kafka_pod_autoscaler;
 
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.ExecutionException;
-
-import org.apache.kafka.clients.admin.KafkaAdminClient;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import com.brandwatch.kafka_pod_autoscaler.cache.AdminClientCache;
+
 @Slf4j
 public class PartitionCountFetcher {
     public int countPartitions(@NonNull String bootstrapServers, @NonNull String topic) {
-        logger.info("Requesting kafka metrics for bootstrapServers={} and topic={}", bootstrapServers, topic);
+        logger.debug("Requesting kafka metrics for bootstrapServers={} and topic={}", bootstrapServers, topic);
 
-        var properties = new Properties();
-        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        try (var adminApi = KafkaAdminClient.create(properties)) {
+        var adminApi = AdminClientCache.get(bootstrapServers);
+        try {
             return adminApi.describeTopics(List.of(topic)).values().get(topic).get().partitions().size();
         } catch (ExecutionException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/cache/AdminClientCache.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/cache/AdminClientCache.java
@@ -1,0 +1,31 @@
+package com.brandwatch.kafka_pod_autoscaler.cache;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+
+public class AdminClientCache {
+    private static final Cache<String, AdminClient> adminClientCache = Caffeine.newBuilder()
+           .expireAfterWrite(Duration.ofMinutes(10))
+           .removalListener((RemovalListener<String, AdminClient>) (key, value, cause) -> {
+               if (value != null) {
+                   value.close();
+               }
+           })
+           .build();
+
+    public static AdminClient get(String bootstrapServers) {
+        return adminClientCache.get(bootstrapServers, s -> {
+            var properties = new Properties();
+            properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+            return KafkaAdminClient.create(properties);
+        });
+    }
+}


### PR DESCRIPTION
They both need clients, usually the same clients, so share with a static helper class