### PR TITLE
feat: Move trigger statuses back to kpa status

### DIFF
--- a/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
+++ b/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
@@ -67,18 +67,6 @@ spec:
                       type: object
                       additionalProperties:
                         type: string
-                    status:
-                      type: object
-                      properties:
-                        inputValue:
-                          type: number
-                          format: double
-                        targetThreshold:
-                          type: number
-                          format: double
-                        recommendedReplicas:
-                          type: integer
-                          format: int32
           status:
             type: object
             properties:
@@ -97,6 +85,24 @@ spec:
               dryRunReplicas:
                 type: integer
                 format: int32
+              triggerResults:
+                type: array
+                nullable: false
+                default: []
+                items:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    inputValue:
+                      type: number
+                      format: double
+                    targetThreshold:
+                      type: number
+                      format: double
+                    recommendedReplicas:
+                      type: integer
+                      format: int32
               partitionCount:
                 type: integer
                 format: int32


### PR DESCRIPTION
We only publish status changes via UpdateControl, so the trigger statuses need to be on the status itself