### PR TITLE
feat: Add a KafkaThroughputTriggerProcessor

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/PartitionCountFetcher.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/PartitionCountFetcher.java
@@ -1,26 +1,16 @@
 package com.brandwatch.kafka_pod_autoscaler;
 
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
-import com.brandwatch.kafka_pod_autoscaler.cache.AdminClientCache;
+import com.brandwatch.kafka_pod_autoscaler.cache.KafkaMetadataCache;
 
 @Slf4j
 public class PartitionCountFetcher {
     public int countPartitions(@NonNull String bootstrapServers, @NonNull String topic) {
         logger.debug("Requesting kafka metrics for bootstrapServers={} and topic={}", bootstrapServers, topic);
 
-        var adminApi = AdminClientCache.get(bootstrapServers);
-        try {
-            return adminApi.describeTopics(List.of(topic)).values().get(topic).get().partitions().size();
-        } catch (ExecutionException e) {
-            throw new RuntimeException(e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
+        var kafkaMetadata = KafkaMetadataCache.get(bootstrapServers);
+        return kafkaMetadata.countPartitions(topic);
     }
 }

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/cache/KafkaMetadata.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/cache/KafkaMetadata.java
@@ -1,0 +1,59 @@
+package com.brandwatch.kafka_pod_autoscaler.cache;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.common.TopicPartition;
+
+public class KafkaMetadata {
+    private final AdminClient adminClient;
+
+    public KafkaMetadata(AdminClient adminClient) {
+        this.adminClient = adminClient;
+    }
+
+    public Map<TopicPartition, Long> getTopicEndOffsets(String topic) throws InterruptedException {
+        try {
+            var partitions = adminClient.describeTopics(List.of(topic)).topicNameValues().get(topic).get().partitions();
+            var latestOffsetRequests = partitions
+                .stream()
+                .collect(Collectors.toMap(p -> new TopicPartition(topic, p.partition()), p -> OffsetSpec.latest()));
+            return adminClient.listOffsets(latestOffsetRequests).all().get().entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset()));
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Map<TopicPartition, Long> getConsumerOffsets(String topic, String consumerGroupId)
+        throws InterruptedException {
+        try {
+            return adminClient.listConsumerGroupOffsets(consumerGroupId)
+                .partitionsToOffsetAndMetadata().get()
+                .entrySet().stream()
+                .filter(tp -> tp.getKey().topic().equals(topic))
+                .collect(Collectors.toMap(Map.Entry::getKey, m -> m.getValue().offset()));
+        } catch (ExecutionException ignored) {
+            // ignore, starting up
+            Thread.sleep(100);
+            return Map.of();
+        }
+    }
+
+    public int countPartitions(String topic) {
+        try {
+            return adminClient.describeTopics(List.of(topic)).values().get(topic).get().partitions().size();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void close() {
+        adminClient.close();
+    }
+}

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -14,7 +14,7 @@ import com.brandwatch.kafka_pod_autoscaler.cache.KafkaMetadataCache;
 
 @Slf4j
 @AutoService(TriggerProcessor.class)
-public class KafkaTriggerProcessor implements TriggerProcessor {
+public class KafkaLagTriggerProcessor implements TriggerProcessor {
     @Override
     public String getType() {
         return "kafka";

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaThroughputTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaThroughputTriggerProcessor.java
@@ -1,0 +1,131 @@
+package com.brandwatch.kafka_pod_autoscaler.triggers;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.auto.service.AutoService;
+
+import brandwatch.com.v1alpha1.KafkaPodAutoscaler;
+import brandwatch.com.v1alpha1.kafkapodautoscalerspec.Triggers;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import com.brandwatch.kafka_pod_autoscaler.ScaledResource;
+import com.brandwatch.kafka_pod_autoscaler.cache.KafkaMetadataCache;
+
+@Slf4j
+@AutoService(TriggerProcessor.class)
+public class KafkaThroughputTriggerProcessor implements TriggerProcessor {
+    private static final LoadingCache<TopicConsumerGroupId, Cache<PartitionTimestamp, Long>> consumerOffsetHistory = Caffeine
+        .newBuilder()
+        .expireAfterAccess(Duration.ofMinutes(5L))
+        .build(key -> Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(10L))
+            .build());
+    private static final LoadingCache<TopicConsumerGroupId, Cache<PartitionTimestamp, Long>> topicEndHistory = Caffeine
+        .newBuilder()
+        .expireAfterAccess(Duration.ofMinutes(5L))
+        .build(key -> Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(10L))
+            .build());
+
+    @Setter // (onMethod_ = { @VisibleForTesting })
+    private Clock clock = Clock.systemUTC();
+
+    @Override
+    public String getType() {
+        return "kafkaThroughput";
+    }
+
+    @Override
+    public TriggerResult process(KubernetesClient client, ScaledResource resource, KafkaPodAutoscaler autoscaler, Triggers trigger, int replicaCount) {
+        var topic = autoscaler.getSpec().getTopicName();
+        var bootstrapServers = autoscaler.getSpec().getBootstrapServers();
+        var consumerGroupId = requireNonNull(trigger.getMetadata().get("consumerGroupId"));
+        var topicConsumerGroupId = new TopicConsumerGroupId(topic, consumerGroupId);
+
+        logger.debug("Requesting kafka metrics for topic={} and consumerGroupId={}", topic, consumerGroupId);
+
+        var adminApi = KafkaMetadataCache.get(bootstrapServers);
+        try {
+            var timestamp = clock.millis();
+            var consumerOffsets = adminApi.getConsumerOffsets(topic, consumerGroupId);
+            var historicConsumerOffsets = consumerOffsetHistory.get(topicConsumerGroupId);
+            historicConsumerOffsets.putAll(consumerOffsets.entrySet().stream()
+                 .collect(Collectors.toMap(e -> new PartitionTimestamp(e.getKey().partition(), timestamp),
+                                           Map.Entry::getValue)));
+            var consumerRate = calculateRate(historicConsumerOffsets);
+
+            var topicEndOffsets = adminApi.getTopicEndOffsets(topic);
+            var historicTopicEndOffsets = topicEndHistory.get(topicConsumerGroupId);
+            historicTopicEndOffsets.putAll(topicEndOffsets.entrySet().stream()
+                .collect(Collectors.toMap(e -> new PartitionTimestamp(e.getKey().partition(), timestamp),
+                                          Map.Entry::getValue)));
+            var producerRate = calculateRate(historicTopicEndOffsets);
+
+            return new TriggerResult(trigger, consumerRate, producerRate);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (RuntimeException e) {
+            KafkaMetadataCache.remove(bootstrapServers);
+            throw e;
+        }
+    }
+
+    private long calculateRate(Cache<PartitionTimestamp, Long> offsets) {
+        var timestamps = offsets.asMap().keySet().stream()
+            .mapToLong(aLong -> aLong.timestamp)
+            .sorted()
+            .distinct()
+            .toArray();
+
+        if (timestamps.length < 2) {
+            return 0;
+        }
+
+        var earliestTimestamp = timestamps[0];
+        var latestTimestamp = timestamps[timestamps.length - 1];
+
+        var timestampDelta = latestTimestamp - earliestTimestamp;
+        if (timestampDelta == 0) {
+            return 0;
+        }
+
+        // Find the slowest-consuming partition
+        var earliestOffsets = offsets.asMap().entrySet().stream()
+            .filter(off -> off.getKey().timestamp() == earliestTimestamp)
+            .collect(Collectors.toMap(off -> off.getKey().partition, off -> off.getValue()));
+        var latestOffsets = offsets.asMap().entrySet().stream()
+            .filter(off -> off.getKey().timestamp() == latestTimestamp)
+            .collect(Collectors.toMap(off -> off.getKey().partition, off -> off.getValue()));
+
+        var smallestOffsetDelta = Long.MAX_VALUE;
+        for (var partition : latestOffsets.keySet()) {
+            if (!earliestOffsets.containsKey(partition)) {
+                continue;
+            }
+            var partitionOffsetDelta = (latestOffsets.get(partition) - earliestOffsets.get(partition));
+            if (partitionOffsetDelta < smallestOffsetDelta) {
+                smallestOffsetDelta = partitionOffsetDelta;
+            }
+        }
+
+        // Return the consumption rate in ops/sec
+        return smallestOffsetDelta / (timestampDelta / 1000);
+    }
+
+    private record TopicConsumerGroupId(String topic, String consumerGroupId) {
+    }
+
+    private record PartitionTimestamp(int partition, long timestamp) {
+    }
+}

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaTriggerProcessor.java
@@ -2,15 +2,6 @@ package com.brandwatch.kafka_pod_autoscaler.triggers;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.OffsetSpec;
-import org.apache.kafka.common.TopicPartition;
-
 import com.google.auto.service.AutoService;
 
 import brandwatch.com.v1alpha1.KafkaPodAutoscaler;
@@ -18,8 +9,8 @@ import brandwatch.com.v1alpha1.kafkapodautoscalerspec.Triggers;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import lombok.extern.slf4j.Slf4j;
 
-import com.brandwatch.kafka_pod_autoscaler.cache.AdminClientCache;
 import com.brandwatch.kafka_pod_autoscaler.ScaledResource;
+import com.brandwatch.kafka_pod_autoscaler.cache.KafkaMetadataCache;
 
 @Slf4j
 @AutoService(TriggerProcessor.class)
@@ -38,44 +29,22 @@ public class KafkaTriggerProcessor implements TriggerProcessor {
 
         logger.debug("Requesting kafka metrics for topic={} and consumerGroupId={}", topic, consumerGroupId);
 
-        var adminApi = AdminClientCache.get(bootstrapServers);
+        var kafkaMetadata = KafkaMetadataCache.get(bootstrapServers);
         try {
-            var partitions = adminApi.describeTopics(List.of(topic)).topicNameValues().get(topic).get().partitions();
-            var latestOffsetRequests = partitions
-                    .stream()
-                    .collect(Collectors.toMap(p -> new TopicPartition(topic, p.partition()), p -> OffsetSpec.latest()));
-
-            var consumerOffsets = getConsumerOffsets(adminApi, topic, consumerGroupId);
-            var topicEndOffsets = adminApi.listOffsets(latestOffsetRequests).all().get().entrySet()
-                                          .stream()
-                                          .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().offset()));
+            var consumerOffsets = kafkaMetadata.getConsumerOffsets(topic, consumerGroupId);
+            var topicEndOffsets = kafkaMetadata.getTopicEndOffsets(topic);
 
             var lag = consumerOffsets.keySet().stream()
                                      .mapToLong(partition -> topicEndOffsets.get(partition) - consumerOffsets.get(partition))
                                      .sum();
 
             return new TriggerResult(trigger, lag, threshold);
-        } catch (ExecutionException e) {
-            AdminClientCache.remove(bootstrapServers);
-            throw new RuntimeException(e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
-        }
-    }
-
-    private static Map<TopicPartition, Long> getConsumerOffsets(AdminClient adminApi, String topic, String consumerGroupId)
-            throws InterruptedException {
-        try {
-            return adminApi.listConsumerGroupOffsets(consumerGroupId)
-                           .partitionsToOffsetAndMetadata().get()
-                           .entrySet().stream()
-                           .filter(tp -> tp.getKey().topic().equals(topic))
-                           .collect(Collectors.toMap(Map.Entry::getKey, m -> m.getValue().offset()));
-        } catch (ExecutionException ignored) {
-            // ignore, starting up
-            Thread.sleep(100);
-            return Map.of();
+        } catch (RuntimeException e) {
+            KafkaMetadataCache.remove(bootstrapServers);
+            throw e;
         }
     }
 }

--- a/src/test/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaThroughputTriggerProcessorTest.java
+++ b/src/test/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaThroughputTriggerProcessorTest.java
@@ -1,0 +1,131 @@
+package com.brandwatch.kafka_pod_autoscaler.triggers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import brandwatch.com.v1alpha1.KafkaPodAutoscaler;
+import brandwatch.com.v1alpha1.KafkaPodAutoscalerSpec;
+import brandwatch.com.v1alpha1.kafkapodautoscalerspec.Triggers;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import com.brandwatch.kafka_pod_autoscaler.ScaledResource;
+import com.brandwatch.kafka_pod_autoscaler.cache.KafkaMetadata;
+import com.brandwatch.kafka_pod_autoscaler.cache.KafkaMetadataCache;
+
+@ExtendWith(MockitoExtension.class)
+public class KafkaThroughputTriggerProcessorTest {
+    private static final String BOOTSTRAP_SERVERS = "KafkaThroughputTriggerProcessorTest";
+    private static final String TOPIC_NAME = "topic";
+    private static final String CONSUMER_GROUP_ID = "consumer-group";
+    private static final Instant NOW = Instant.parse("2000-01-02T03:04:05.0006Z");
+
+    @Mock
+    private KafkaMetadata kafkaMetadata;
+    @Mock
+    private KubernetesClient client;
+    @Mock
+    private ScaledResource resource;
+    @Mock
+    private KafkaPodAutoscaler autoscaler;
+    @Mock
+    private Triggers trigger;
+
+    private final KafkaThroughputTriggerProcessor triggerProcessor = new KafkaThroughputTriggerProcessor();
+
+    @BeforeEach
+    public void before() {
+        KafkaMetadataCache.put(BOOTSTRAP_SERVERS, kafkaMetadata);
+
+        var spec = new KafkaPodAutoscalerSpec();
+        spec.setTopicName(TOPIC_NAME);
+        spec.setBootstrapServers(BOOTSTRAP_SERVERS);
+        when(autoscaler.getSpec()).thenReturn(spec);
+
+        when(trigger.getMetadata()).thenReturn(Map.of("consumerGroupId", CONSUMER_GROUP_ID));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    public void canCalculateRate(String name, List<TopicOffsets> topicOffsets, long expectedInputValue, long expectedTargetThresold)
+            throws InterruptedException {
+        var seconds = 0;
+
+        TriggerResult triggerResult = null;
+        for (var topicOffset : topicOffsets) {
+            triggerProcessor.setClock(Clock.fixed(NOW.plusSeconds(seconds++), ZoneOffset.UTC));
+
+            givenConsumerOffsets(topicOffset.consumerOffsets());
+            givenTopicEndOffsets(topicOffset.topicEndOffsets());
+            triggerResult = triggerProcessor.process(client, resource, autoscaler, trigger, 1);
+        }
+        assertThat(triggerResult.inputValue()).isEqualTo(expectedInputValue);
+        assertThat(triggerResult.targetThreshold()).isEqualTo(expectedTargetThresold);
+    }
+
+    public static Stream<Arguments> canCalculateRate() {
+        return Stream.of(
+            Arguments.of(
+                "All partitions consuming at same rate",
+                List.of(
+                    new TopicOffsets(new long[] { 5, 5, 5, 5 }, new long[] { 10, 10, 10, 10 }),
+                    new TopicOffsets(new long[] { 10, 10, 10, 10 }, new long[] { 20, 20, 20, 20 })
+                ),
+                5L,
+                10L
+            ),
+            Arguments.of(
+                "Takes the rate of the slowest consuming partition",
+                List.of(
+                    new TopicOffsets(new long[] { 5, 5, 5, 5 }, new long[] { 10, 10, 10, 10 }),
+                    new TopicOffsets(new long[] { 8, 7, 6, 9 }, new long[] { 20, 20, 20, 20 })
+                ),
+                1L,
+                10L
+            )
+        );
+    }
+
+    private void givenConsumerOffsets(long... partitionValues) throws InterruptedException {
+        var partitionOffsets = new HashMap<TopicPartition, Long>();
+        for (var i = 0; i < partitionValues.length; i++) {
+            var offset = partitionValues[i];
+
+            partitionOffsets.put(new TopicPartition(TOPIC_NAME, i), offset);
+        }
+
+        when(kafkaMetadata.getConsumerOffsets(TOPIC_NAME, CONSUMER_GROUP_ID))
+            .thenReturn(partitionOffsets);
+    }
+
+    private void givenTopicEndOffsets(long... partitionValues) throws InterruptedException {
+        var partitionOffsets = new HashMap<TopicPartition, Long>();
+        for (var i = 0; i < partitionValues.length; i++) {
+            var offset = partitionValues[i];
+
+            partitionOffsets.put(new TopicPartition(TOPIC_NAME, i), offset);
+        }
+
+        when(kafkaMetadata.getTopicEndOffsets(TOPIC_NAME))
+            .thenReturn(partitionOffsets);
+    }
+
+    private record TopicOffsets(long[] consumerOffsets, long[] topicEndOffsets) {
+    }
+}


### PR DESCRIPTION
This trigger type compares the rate of change to the 'head' offsets of a topic to the rate of change to the consumers' offsets on the topic, and produces scaling recommendations that aim to bring the two rates closer together