### PR TITLE
fix: use correct Operator constructor

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/Main.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/Main.java
@@ -29,7 +29,8 @@ public class Main {
         Metrics.globalRegistry.add(registry);
         var leaderElectionConfiguration = new LeaderElectionConfiguration("kafka-pod-autoscaler");
         var client = new KubernetesClientBuilder().build();
-        Operator operator = new Operator(client, c -> c
+        Operator operator = new Operator(c -> c
+                .withKubernetesClient(client)
                 .withLeaderElectionConfiguration(leaderElectionConfiguration)
                 .withMetrics(MicrometerMetrics.withoutPerResourceMetrics(Metrics.globalRegistry))
         );


### PR DESCRIPTION
The one we were using has been deprecated, use `withKubernetesClient` to pass in the client as per the docs