### PR TITLE
feat: change kafka trigger to use consumption rates

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -2,7 +2,6 @@ name: Check commits messages
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, edited, synchronize]
 
 jobs:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 concurrency:
   group: maven-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ spec:
   triggers:
     - type: static # for testing
       metadata:
-        replicas: 2
+        replicas: [Required]
     - type: cpu
       metadata:
-        threshold: 
+        threshold: [Required]
     - type: prometheus
       metadata:
         serverAddress: 
@@ -37,8 +37,9 @@ spec:
         threshold: 
     - type: kafka
       metadata:
-        consumerGroupId:
-        threshold: 
+        consumerGroupId: [Required]
+        threshold: [Required] 
+        sla: P10M
 ```
 
 

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -2,6 +2,11 @@ package com.brandwatch.kafka_pod_autoscaler.triggers;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
+import java.util.Optional;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.auto.service.AutoService;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -9,12 +14,17 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.brandwatch.kafka_pod_autoscaler.ScaledResource;
 import com.brandwatch.kafka_pod_autoscaler.cache.KafkaMetadataCache;
+import com.brandwatch.kafka_pod_autoscaler.triggers.kafka.LagMetrics;
 import com.brandwatch.kafka_pod_autoscaler.v1alpha1.KafkaPodAutoscaler;
 import com.brandwatch.kafka_pod_autoscaler.v1alpha1.kafkapodautoscalerspec.TriggerDefinition;
 
 @Slf4j
 @AutoService(TriggerProcessor.class)
 public class KafkaLagTriggerProcessor implements TriggerProcessor {
+    private final LoadingCache<TopicConsumerGroupId, LagMetrics> lagMetricsCache = Caffeine.newBuilder()
+        .expireAfterAccess(Duration.ofMinutes(10))
+        .build(id -> new LagMetrics());
+
     @Override
     public String getType() {
         return "kafka";
@@ -26,19 +36,40 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
         var bootstrapServers = autoscaler.getSpec().getBootstrapServers();
         var consumerGroupId = requireNonNull(trigger.getMetadata().get("consumerGroupId"));
         var threshold = Integer.parseInt(requireNonNull(trigger.getMetadata().get("threshold")));
+        var sla = Duration.parse(Optional.ofNullable(trigger.getMetadata().get("sla")).orElse("P10M"));
 
         logger.debug("Requesting kafka metrics for topic={} and consumerGroupId={}", topic, consumerGroupId);
 
+        var lagMetrics = lagMetricsCache.get(new TopicConsumerGroupId(topic, consumerGroupId));
         var kafkaMetadata = KafkaMetadataCache.get(bootstrapServers);
         try {
             var consumerOffsets = kafkaMetadata.getConsumerOffsets(topic, consumerGroupId);
             var topicEndOffsets = kafkaMetadata.getTopicEndOffsets(topic);
 
             var lag = consumerOffsets.keySet().stream()
-                                     .mapToLong(partition -> topicEndOffsets.get(partition) - consumerOffsets.get(partition))
-                                     .sum();
+                .mapToLong(partition -> topicEndOffsets.get(partition) - consumerOffsets.get(partition))
+                .sum();
 
-            return new TriggerResult(trigger, lag, threshold);
+            double consumerRate;
+            var targetRate = lagMetrics.calculateAndRecordTopicRate(topicEndOffsets);
+            if (lag < threshold) {
+                // ensure the consumers are fast enough to keep up and not start lagging, at this rate
+                consumerRate = lagMetrics.estimateLoadedConsumerRate(replicaCount).orElse(targetRate);
+
+                // Make the consumer rate the target (swap them around)
+                // We're usually dealing in scaling _up_ until the values meet, but in this case we want to scale _down_ (potentially)
+                return new TriggerResult(trigger, targetRate, consumerRate);
+            } else {
+                consumerRate = lagMetrics.calculateConsumerRate(replicaCount, consumerOffsets);
+                // Record this consumer rate as a rate-under-load, so we can use it to calculate the ideal replica count when not lagged
+                lagMetrics.recordConsumerRate(replicaCount, consumerOffsets);
+
+                // We need to catch up, so calculate a target rate that will clear the lag within the SLA
+                var rateRequiredToClearLag = lag / (double) sla.toSeconds();
+                targetRate = targetRate + rateRequiredToClearLag;
+
+                return new TriggerResult(trigger, consumerRate, targetRate);
+            }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -46,5 +77,8 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
             KafkaMetadataCache.remove(bootstrapServers);
             throw e;
         }
+    }
+
+    private record TopicConsumerGroupId(String topic, String consumerGroupId) {
     }
 }

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetrics.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetrics.java
@@ -1,0 +1,163 @@
+package com.brandwatch.kafka_pod_autoscaler.triggers.kafka;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+import org.apache.kafka.common.TopicPartition;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class LagMetrics {
+    private final LongSupplier clock;
+    private final Duration offsetRetention;
+
+    private final Map<Integer, List<RecordedOffsets>> historicalConsumerOffsets = new ConcurrentHashMap<>();
+    private final List<RecordedOffsets> historicalEndOffsets = new ArrayList<>();
+
+    public LagMetrics() {
+        this(System::currentTimeMillis);
+    }
+
+    @VisibleForTesting
+    LagMetrics(LongSupplier clock) {
+        this(clock, Duration.ofMinutes(5));
+    }
+
+    @VisibleForTesting
+    LagMetrics(LongSupplier clock, Duration offsetRetention) {
+        this.clock = clock;
+        this.offsetRetention = offsetRetention;
+    }
+
+    public double calculateConsumerRate(int replicaCount, Map<TopicPartition, Long> consumerOffsets) {
+        var historicalOffsets = historicalConsumerOffsets.get(replicaCount);
+
+        // Choose the replicaCount "nearest" to this one if missing
+        var substituteReplicaCount = replicaCount;
+        if (historicalOffsets == null || historicalOffsets.isEmpty()) {
+            substituteReplicaCount = findNearestReplicaCountTo(replicaCount);
+            historicalOffsets = historicalConsumerOffsets.get(substituteReplicaCount);
+        }
+
+        if (historicalOffsets == null) {
+            return 0;
+        }
+
+        // If we chose an alternative replica count, we need to scale it to match this replica count
+        var scaleFactor = (substituteReplicaCount / (double) replicaCount);
+        return calculateRate(historicalOffsets, new RecordedOffsets(clock.getAsLong(), consumerOffsets))
+            .orElse(0) * scaleFactor;
+    }
+
+    public double calculateAndRecordTopicRate(Map<TopicPartition, Long> topicEndOffsets) {
+        var offsetsToRecord = new RecordedOffsets(clock.getAsLong(), topicEndOffsets);
+        var rate = calculateRate(historicalEndOffsets, offsetsToRecord);
+        historicalEndOffsets.add(offsetsToRecord);
+        pruneOffsets(historicalEndOffsets);
+        return rate.orElse(0);
+    }
+
+    public OptionalDouble estimateLoadedConsumerRate(int replicaCount) {
+        var historicalOffsets = historicalConsumerOffsets.get(replicaCount);
+
+        // Choose the replicaCount "nearest" to this one if missing
+        var substituteReplicaCount = replicaCount;
+        if (historicalOffsets == null || historicalOffsets.isEmpty()) {
+            substituteReplicaCount = findNearestReplicaCountTo(replicaCount);
+            historicalOffsets = historicalConsumerOffsets.get(substituteReplicaCount);
+        }
+
+        if (historicalOffsets == null) {
+            return OptionalDouble.empty();
+        }
+
+        // If we chose an alternative replica count, we need to scale it to match this replica count
+        var scaleFactor = (substituteReplicaCount / (double) replicaCount);
+        return calculateRate(historicalOffsets).stream().map(d -> d * scaleFactor).findFirst();
+    }
+
+    private int findNearestReplicaCountTo(int replicaCount) {
+        var substituteReplicaCount = replicaCount;
+        var replicaCountDelta = Integer.MAX_VALUE;
+        for (var otherReplicaCount : historicalConsumerOffsets.keySet()) {
+            var thisDelta = Math.abs(otherReplicaCount - replicaCount);
+            if (thisDelta < replicaCountDelta) {
+                substituteReplicaCount = otherReplicaCount;
+                replicaCountDelta = thisDelta;
+            }
+        }
+        return substituteReplicaCount;
+    }
+
+    public void recordConsumerRate(int replicaCount, Map<TopicPartition, Long> consumerOffsets) {
+        var historical = historicalConsumerOffsets.computeIfAbsent(replicaCount, c -> new ArrayList<>());
+
+        historical.add(new RecordedOffsets(clock.getAsLong(), consumerOffsets));
+
+        pruneOffsets(historical);
+    }
+
+    private OptionalDouble calculateRate(List<RecordedOffsets> historicalOffsets) {
+        var latestOffsets = historicalOffsets.stream()
+            .max(Comparator.comparing(off -> off.timestamp));
+
+        return latestOffsets.map(recordedOffsets -> calculateRate(historicalOffsets, recordedOffsets))
+            .orElseGet(OptionalDouble::empty);
+    }
+
+    private OptionalDouble calculateRate(List<RecordedOffsets> historicalOffsets, RecordedOffsets latestOffsets) {
+        var maybeEarliestOffsets = historicalOffsets.stream()
+            .min(Comparator.comparing(off -> off.timestamp));
+
+        if (maybeEarliestOffsets.isEmpty()) {
+            return OptionalDouble.empty();
+        }
+        var earliestOffsets = maybeEarliestOffsets.get();
+
+        var timestampDelta = latestOffsets.timestamp - earliestOffsets.timestamp;
+
+        if (timestampDelta == 0) {
+            return OptionalDouble.empty();
+        }
+
+        var smallestOffsetDelta = Long.MAX_VALUE;
+        for (var partition : latestOffsets.offsets().keySet()) {
+            if (!earliestOffsets.offsets().containsKey(partition)) {
+                continue;
+            }
+            var partitionOffsetDelta = (latestOffsets.offsets().get(partition) - earliestOffsets.offsets().get(partition));
+            if (partitionOffsetDelta < smallestOffsetDelta) {
+                smallestOffsetDelta = partitionOffsetDelta;
+            }
+        }
+
+        // Return the consumption rate in ops/sec
+        return OptionalDouble.of(smallestOffsetDelta / (timestampDelta / 1000D));
+    }
+
+    private void pruneOffsets(List<RecordedOffsets> historicalOffsets) {
+        // Always keep the most recent offsets
+        var maybeMostRecentOffsets = historicalOffsets.stream()
+            .max(Comparator.comparing(off -> off.timestamp));
+
+        if (maybeMostRecentOffsets.isEmpty()) {
+            return;
+        }
+
+        var cutoff = clock.getAsLong() - offsetRetention.toMillis();
+        historicalOffsets.removeIf(off -> off.timestamp() < cutoff);
+
+        if (!historicalOffsets.contains(maybeMostRecentOffsets.get())) {
+            historicalOffsets.add(maybeMostRecentOffsets.get());
+        }
+    }
+
+    record RecordedOffsets(long timestamp, Map<TopicPartition, Long> offsets) {
+    }
+}

--- a/src/test/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetricsTest.java
+++ b/src/test/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetricsTest.java
@@ -1,0 +1,115 @@
+package com.brandwatch.kafka_pod_autoscaler.triggers.kafka;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalDouble;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class LagMetricsTest {
+    private static final Instant NOW = Instant.parse("2000-01-02T03:04:05.006Z");
+    private static final TopicPartition PARTITION_1 = new TopicPartition("topic", 1);
+    private static final TopicPartition PARTITION_2 = new TopicPartition("topic", 2);
+    private static final TopicPartition PARTITION_3 = new TopicPartition("topic", 3);
+    private static final TopicPartition PARTITION_4 = new TopicPartition("topic", 4);
+    private static final Map<TopicPartition, Long> OFFSETS_1 = Map.of(
+        PARTITION_1, 0L,
+        PARTITION_2, 0L,
+        PARTITION_3, 0L,
+        PARTITION_4, 0L
+    );
+    private static final Map<TopicPartition, Long> OFFSETS_2 = Map.of(
+        PARTITION_1, 1L,
+        PARTITION_2, 1L,
+        PARTITION_3, 1L,
+        PARTITION_4, 1L
+    );
+
+    @ParameterizedTest
+    @MethodSource
+    public void calculateConsumerRate(int previousReplicaCount,
+                                      List<Map<TopicPartition, Long>> previousConsumerOffsets,
+                                      Map<TopicPartition, Long> consumerOffsets,
+                                      int calculateUsingReplicaCount,
+                                      double expectedConsumerRate) {
+        var clock = new AtomicLong(NOW.toEpochMilli());
+        var lagMetrics = new LagMetrics(clock::get);
+
+        for (var previousOffsets : previousConsumerOffsets) {
+            lagMetrics.recordConsumerRate(previousReplicaCount, previousOffsets);
+            clock.addAndGet(1_000);
+        }
+
+        var consumerRate = lagMetrics.calculateConsumerRate(calculateUsingReplicaCount, consumerOffsets);
+        assertThat(consumerRate).isEqualTo(expectedConsumerRate);
+    }
+
+    public static Stream<Arguments> calculateConsumerRate() {
+        return Stream.of(
+            Arguments.of(1, List.of(), OFFSETS_1, 1, 0D),
+            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_2, 1, 1D),
+            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_2, 2, 0.5D),
+            Arguments.of(2, List.of(OFFSETS_1), OFFSETS_2, 1, 2D)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void estimateLoadedConsumerRate(int previousReplicaCount,
+                                      List<Map<TopicPartition, Long>> previousConsumerOffsets,
+                                      int calculateUsingReplicaCount,
+                                      OptionalDouble expectedConsumerRate) {
+        var clock = new AtomicLong(NOW.toEpochMilli());
+        var lagMetrics = new LagMetrics(clock::get);
+
+        for (var previousOffsets : previousConsumerOffsets) {
+            lagMetrics.recordConsumerRate(previousReplicaCount, previousOffsets);
+            clock.addAndGet(1_000);
+        }
+
+        var consumerRate = lagMetrics.estimateLoadedConsumerRate(calculateUsingReplicaCount);
+        assertThat(consumerRate).isEqualTo(expectedConsumerRate);
+    }
+
+    public static Stream<Arguments> estimateLoadedConsumerRate() {
+        return Stream.of(
+            Arguments.of(1, List.of(), 1, OptionalDouble.empty()),
+            Arguments.of(1, List.of(OFFSETS_1), 1, OptionalDouble.empty()),
+            Arguments.of(1, List.of(OFFSETS_1, OFFSETS_2), 1, OptionalDouble.of(1D)),
+            Arguments.of(1, List.of(OFFSETS_1, OFFSETS_2), 2, OptionalDouble.of(0.5D)),
+            Arguments.of(2, List.of(OFFSETS_1, OFFSETS_2), 1, OptionalDouble.of(2D))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void calculateAndRecordTopicRate(List<Map<TopicPartition, Long>> previousTopicEndOffsets,
+                                      Map<TopicPartition, Long> topicEndOffsets,
+                                      double expectedTopicRate) {
+        var clock = new AtomicLong(NOW.toEpochMilli());
+        var lagMetrics = new LagMetrics(clock::get);
+
+        for (var previousOffsets : previousTopicEndOffsets) {
+            lagMetrics.calculateAndRecordTopicRate(previousOffsets);
+            clock.addAndGet(1_000);
+        }
+
+        var consumerRate = lagMetrics.calculateAndRecordTopicRate(topicEndOffsets);
+        assertThat(consumerRate).isEqualTo(expectedTopicRate);
+    }
+
+    public static Stream<Arguments> calculateAndRecordTopicRate() {
+        return Stream.of(
+            Arguments.of(List.of(), OFFSETS_1, 0D),
+            Arguments.of(List.of(OFFSETS_1), OFFSETS_2, 1D)
+        );
+    }
+}


### PR DESCRIPTION
Simply targetting a certain lag value leads to overscaling in some instances, and underscaling in others

For example, if we drop under the lag threshold we might scale down, but the consumers may not be able to keep up with the new number of replicas, so we'd build lag then scale up again later

This change makes the KafkaLagTriggerProcessor target throughput on the topic instead of an absolute lag value. If we're under the lag threshold we use historic throughput values to calculate whether we're under or over the throughput into the head of the topic itself.  If we're over the lag threshold we use an 'sla' target to calculate the correct number of replicas needed to clear own the lag in a given period of time (default 10 minutes)