### PR TITLE
fix: handle unchanging offsets in consumer rate calculation

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -51,7 +51,7 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
                 .sum();
 
             double consumerRate;
-            var targetRate = lagMetrics.calculateAndRecordTopicRate(topicEndOffsets);
+            var targetRate = lagMetrics.calculateAndRecordTopicRate(topicEndOffsets).orElse(0);
             if (lag < threshold) {
                 // ensure the consumers are fast enough to keep up and not start lagging, at this rate
                 consumerRate = lagMetrics.estimateLoadedConsumerRate(replicaCount).orElse(targetRate);
@@ -60,7 +60,7 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
                 // We're usually dealing in scaling _up_ until the values meet, but in this case we want to scale _down_ (potentially)
                 return new TriggerResult(trigger, targetRate, consumerRate);
             } else {
-                consumerRate = lagMetrics.calculateConsumerRate(replicaCount, consumerOffsets);
+                consumerRate = lagMetrics.calculateConsumerRate(replicaCount, consumerOffsets).orElse(0);
                 // Record this consumer rate as a rate-under-load, so we can use it to calculate the ideal replica count when not lagged
                 lagMetrics.recordConsumerRate(replicaCount, consumerOffsets);
 

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetrics.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetrics.java
@@ -132,9 +132,13 @@ public class LagMetrics {
                 continue;
             }
             var partitionOffsetDelta = (latestOffsets.offsets().get(partition) - earliestOffsets.offsets().get(partition));
-            if (partitionOffsetDelta < smallestOffsetDelta) {
+            if (partitionOffsetDelta > 0 && partitionOffsetDelta < smallestOffsetDelta) {
                 smallestOffsetDelta = partitionOffsetDelta;
             }
+        }
+
+        if (smallestOffsetDelta == Long.MAX_VALUE) {
+            return OptionalDouble.empty();
         }
 
         // Return the consumption rate in ops/sec

--- a/src/test/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetricsTest.java
+++ b/src/test/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetricsTest.java
@@ -55,6 +55,7 @@ public class LagMetricsTest {
     public static Stream<Arguments> calculateConsumerRate() {
         return Stream.of(
             Arguments.of(1, List.of(), OFFSETS_1, 1, 0D),
+            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_1, 1, 0D),
             Arguments.of(1, List.of(OFFSETS_1), OFFSETS_2, 1, 1D),
             Arguments.of(1, List.of(OFFSETS_1), OFFSETS_2, 2, 0.5D),
             Arguments.of(2, List.of(OFFSETS_1), OFFSETS_2, 1, 2D)
@@ -83,6 +84,7 @@ public class LagMetricsTest {
         return Stream.of(
             Arguments.of(1, List.of(), 1, OptionalDouble.empty()),
             Arguments.of(1, List.of(OFFSETS_1), 1, OptionalDouble.empty()),
+            Arguments.of(1, List.of(OFFSETS_1, OFFSETS_1), 1, OptionalDouble.empty()),
             Arguments.of(1, List.of(OFFSETS_1, OFFSETS_2), 1, OptionalDouble.of(1D)),
             Arguments.of(1, List.of(OFFSETS_1, OFFSETS_2), 2, OptionalDouble.of(0.5D)),
             Arguments.of(2, List.of(OFFSETS_1, OFFSETS_2), 1, OptionalDouble.of(2D))
@@ -109,6 +111,7 @@ public class LagMetricsTest {
     public static Stream<Arguments> calculateAndRecordTopicRate() {
         return Stream.of(
             Arguments.of(List.of(), OFFSETS_1, 0D),
+            Arguments.of(List.of(OFFSETS_1), OFFSETS_1, 0D),
             Arguments.of(List.of(OFFSETS_1), OFFSETS_2, 1D)
         );
     }

--- a/src/test/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetricsTest.java
+++ b/src/test/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetricsTest.java
@@ -39,7 +39,7 @@ public class LagMetricsTest {
                                       List<Map<TopicPartition, Long>> previousConsumerOffsets,
                                       Map<TopicPartition, Long> consumerOffsets,
                                       int calculateUsingReplicaCount,
-                                      double expectedConsumerRate) {
+                                      OptionalDouble expectedConsumerRate) {
         var clock = new AtomicLong(NOW.toEpochMilli());
         var lagMetrics = new LagMetrics(clock::get);
 
@@ -54,11 +54,11 @@ public class LagMetricsTest {
 
     public static Stream<Arguments> calculateConsumerRate() {
         return Stream.of(
-            Arguments.of(1, List.of(), OFFSETS_1, 1, 0D),
-            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_1, 1, 0D),
-            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_2, 1, 1D),
-            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_2, 2, 0.5D),
-            Arguments.of(2, List.of(OFFSETS_1), OFFSETS_2, 1, 2D)
+            Arguments.of(1, List.of(), OFFSETS_1, 1, OptionalDouble.empty()),
+            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_1, 1, OptionalDouble.empty()),
+            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_2, 1, OptionalDouble.of(1D)),
+            Arguments.of(1, List.of(OFFSETS_1), OFFSETS_2, 2, OptionalDouble.of(0.5D)),
+            Arguments.of(2, List.of(OFFSETS_1), OFFSETS_2, 1, OptionalDouble.of(2D))
         );
     }
 
@@ -95,7 +95,7 @@ public class LagMetricsTest {
     @MethodSource
     public void calculateAndRecordTopicRate(List<Map<TopicPartition, Long>> previousTopicEndOffsets,
                                       Map<TopicPartition, Long> topicEndOffsets,
-                                      double expectedTopicRate) {
+                                      OptionalDouble expectedTopicRate) {
         var clock = new AtomicLong(NOW.toEpochMilli());
         var lagMetrics = new LagMetrics(clock::get);
 
@@ -110,9 +110,9 @@ public class LagMetricsTest {
 
     public static Stream<Arguments> calculateAndRecordTopicRate() {
         return Stream.of(
-            Arguments.of(List.of(), OFFSETS_1, 0D),
-            Arguments.of(List.of(OFFSETS_1), OFFSETS_1, 0D),
-            Arguments.of(List.of(OFFSETS_1), OFFSETS_2, 1D)
+            Arguments.of(List.of(), OFFSETS_1, OptionalDouble.empty()),
+            Arguments.of(List.of(OFFSETS_1), OFFSETS_1, OptionalDouble.empty()),
+            Arguments.of(List.of(OFFSETS_1), OFFSETS_2, OptionalDouble.of(1D))
         );
     }
 }


### PR DESCRIPTION
If we can't find any non-zero offset changes then we shouldn't use those for rate calculations, fall back instead