### PR TITLE
fix: Add printer columns to CRD

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,6 +47,8 @@ jobs:
           echo "No unstaged changes"
         else
           echo "There are unstaged changes after the Maven build.  Did you check in the updated CRD?"
+          git status
+          git diff
           exit 1
         fi
 

--- a/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
+++ b/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
@@ -14,7 +14,33 @@ spec:
     singular: kafkapodautoscaler
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.scaleTargetRef.kind
+      name: Target Kind
+      priority: 0
+      type: string
+    - jsonPath: .spec.scaleTargetRef.name
+      name: Target Name
+      priority: 0
+      type: string
+    - jsonPath: .status.currentReplicaCount
+      name: Replicas
+      priority: 0
+      type: integer
+    - description: The date and time that this message was added
+      jsonPath: .status.lastScale
+      name: Last Scale
+      priority: 0
+      type: string
+    - jsonPath: .status.message
+      name: Message
+      priority: 0
+      type: string
+    - jsonPath: .status.partitionCount
+      name: Partition Count
+      priority: 0
+      type: integer
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/KafkaPodAutoscalerStatus.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/KafkaPodAutoscalerStatus.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
+import io.fabric8.kubernetes.model.annotation.PrinterColumn;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -31,6 +32,7 @@ public class KafkaPodAutoscalerStatus implements KubernetesResource {
     @Setter
     @JsonProperty("currentReplicaCount")
     @JsonSetter(nulls = Nulls.SKIP)
+    @PrinterColumn(name = "Replicas")
     private Integer currentReplicaCount;
     @Getter
     @Setter
@@ -50,16 +52,19 @@ public class KafkaPodAutoscalerStatus implements KubernetesResource {
     @JsonProperty("lastScale")
     @JsonPropertyDescription("The date and time that this message was added")
     @JsonSetter(nulls = Nulls.SKIP)
+    @PrinterColumn(name = "Last Scale")
     private String lastScale;
     @Getter
     @Setter
     @JsonProperty("message")
     @JsonSetter(nulls = Nulls.SKIP)
+    @PrinterColumn(name = "Message")
     private String message;
     @Getter
     @Setter
     @JsonProperty("partitionCount")
     @JsonSetter(nulls = Nulls.SKIP)
+    @PrinterColumn(name = "Partition Count")
     private Integer partitionCount;
     /**
      * The date and time that this message was added

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/kafkapodautoscalerspec/ScaleTargetRef.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/kafkapodautoscalerspec/ScaleTargetRef.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import io.fabric8.generator.annotation.Required;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.model.annotation.PrinterColumn;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,11 +28,13 @@ public class ScaleTargetRef implements KubernetesResource {
     @JsonProperty("kind")
     @Required
     @JsonSetter(nulls = Nulls.SKIP)
+    @PrinterColumn(name = "Target Kind")
     private String kind = "Deployment";
     @Getter
     @Setter
     @JsonProperty("name")
     @Required
     @JsonSetter(nulls = Nulls.SKIP)
+    @PrinterColumn(name = "Target Name")
     private String name;
 }


### PR DESCRIPTION
This should make kubectl/k9s print out these columns when we view KPAs