### PR TITLE
feat: allow TriggerResults to be inverted

### DIFF
--- a/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
+++ b/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
@@ -113,6 +113,8 @@ spec:
                       type: number
                     type:
                       type: string
+                    inverted:
+                      type: boolean
                   type: object
                 type: array
             type: object

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/KafkaPodAutoscalerReconciler.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/KafkaPodAutoscalerReconciler.java
@@ -284,6 +284,7 @@ public class KafkaPodAutoscalerReconciler implements Reconciler<KafkaPodAutoscal
         public void recordTriggerResult(com.brandwatch.kafka_pod_autoscaler.triggers.TriggerResult result, int recommendedReplicas) {
             var triggerResults = new TriggerResult();
             triggerResults.setType(result.trigger().getType());
+            triggerResults.setInverted(result.inverted());
             triggerResults.setInputValue(result.inputValue());
             triggerResults.setTargetThreshold(result.targetThreshold());
             triggerResults.setRecommendedReplicas(recommendedReplicas);

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -56,9 +56,9 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
                 // ensure the consumers are fast enough to keep up and not start lagging, at this rate
                 consumerRate = lagMetrics.estimateLoadedConsumerRate(replicaCount).orElse(targetRate);
 
-                // Make the consumer rate the target (swap them around)
-                // We're usually dealing in scaling _up_ until the values meet, but in this case we want to scale _down_ (potentially)
-                return new TriggerResult(trigger, targetRate, consumerRate);
+                // Invert the TriggerResult
+                // We're usually dealing in scaling _up_ until the values meet, but in this case we want to scale _down_
+                return TriggerResult.inverted(trigger, consumerRate, targetRate);
             } else {
                 consumerRate = lagMetrics.calculateConsumerRate(replicaCount, consumerOffsets).orElse(0);
                 // Record this consumer rate as a rate-under-load, so we can use it to calculate the ideal replica count when not lagged

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/TriggerResult.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/TriggerResult.java
@@ -2,8 +2,19 @@ package com.brandwatch.kafka_pod_autoscaler.triggers;
 
 import com.brandwatch.kafka_pod_autoscaler.v1alpha1.kafkapodautoscalerspec.TriggerDefinition;
 
-public record TriggerResult(TriggerDefinition trigger, double inputValue, double targetThreshold) {
+public record TriggerResult(TriggerDefinition trigger, double inputValue, double targetThreshold, boolean inverted) {
+    public TriggerResult(TriggerDefinition trigger, double inputValue, double targetThreshold) {
+        this(trigger, inputValue, targetThreshold, false);
+    }
+
     public int recommendedReplicas(int currentReplicaCount) {
+        if (inverted) {
+            return (int) Math.ceil(currentReplicaCount * (targetThreshold / inputValue));
+        }
         return (int) Math.ceil(currentReplicaCount * (inputValue / targetThreshold));
+    }
+
+    public static TriggerResult inverted(TriggerDefinition trigger, double inputValue, double targetThreshold) {
+        return new TriggerResult(trigger, inputValue, targetThreshold, true);
     }
 }

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/kafkapodautoscalerstatus/TriggerResult.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/kafkapodautoscalerstatus/TriggerResult.java
@@ -15,7 +15,6 @@ import lombok.Setter;
 @JsonPropertyOrder({"inputValue","recommendedReplicas","targetThreshold","type"})
 @JsonDeserialize
 public class TriggerResult implements KubernetesResource {
-
     @Getter
     @Setter
     @JsonProperty("inputValue")
@@ -36,4 +35,8 @@ public class TriggerResult implements KubernetesResource {
     @JsonProperty("type")
     @JsonSetter(nulls = Nulls.SKIP)
     private String type;
+    @Getter
+    @Setter
+    @JsonProperty("inverted")
+    private boolean inverted;
 }


### PR DESCRIPTION
Instead of handling cases where the scaling semantics change by simply flipping the current/target values, add an explicit flag to say the trigger is inverted, then we can expose it on the KPA status