### PR TITLE
fix: use/record current consumer rate if it's better than the estimate

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -54,7 +54,7 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
             var targetRate = lagMetrics.calculateAndRecordTopicRate(topicEndOffsets).orElse(0);
             if (lag < threshold) {
                 // ensure the consumers are fast enough to keep up and not start lagging, at this rate
-                consumerRate = lagMetrics.estimateLoadedConsumerRate(replicaCount).orElse(targetRate);
+                consumerRate = lagMetrics.estimateLoadedConsumerRate(replicaCount, consumerOffsets).orElse(targetRate);
 
                 // Make the consumer rate the target (swap them around)
                 // We're usually dealing in scaling _up_ until the values meet, but in this case we want to scale _down_ (potentially)


### PR DESCRIPTION
This should allow us to avoid scaling if we're not yet lagged