### PR TITLE
fix: increase retention for kafka lag metrics

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetrics.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/LagMetrics.java
@@ -26,7 +26,7 @@ public class LagMetrics {
 
     @VisibleForTesting
     LagMetrics(LongSupplier clock) {
-        this(clock, Duration.ofMinutes(5));
+        this(clock, Duration.ofMinutes(60));
     }
 
     @VisibleForTesting


### PR DESCRIPTION
To improve the accuracy of results