### PR TITLE
feat: support maxScaleIncrements configuration on KPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ metadata:
 spec:
   dryRun: false # set true to see what the autoscaler _would_ do
   cooloffSeconds: 300
+  maxScaleIncrements: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
+++ b/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
@@ -78,6 +78,8 @@ spec:
                       type: object
                   type: object
                 type: array
+              maxScaleIncrements:
+                type: integer
             required:
             - scaleTargetRef
             - triggers

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/KafkaPodAutoscalerSpec.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/KafkaPodAutoscalerSpec.java
@@ -55,4 +55,9 @@ public class KafkaPodAutoscalerSpec implements KubernetesResource {
     @Required
     @JsonSetter(nulls = Nulls.SKIP)
     private List<TriggerDefinition> triggers = Serialization.unmarshal("[]", List.class);
+    @Getter
+    @Setter
+    @JsonProperty("maxScaleIncrements")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private int maxScaleIncrements = 1;
 }


### PR DESCRIPTION
This limits the number of increments that the scaler will scale up/down by in one go. eg if there is currently 1 replica and we calculate we need 4, we'll scale up to 2 first then see what's what after `cooloffSeconds` has passed