### PR TITLE
fix: don't record consumer rate if offsets haven't been committed rec…

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -42,6 +42,7 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
         var minimumTopicRateMeasurements = Optional.ofNullable(trigger.getMetadata().get("minimumTopicRateMeasurements")).map(Long::parseLong).orElse(3L);
         var consumerRatePercentile = Optional.ofNullable(trigger.getMetadata().get("consumerRatePercentile")).map(Double::parseDouble).orElse(99D);
         var minimumConsumerRateMeasurements = Optional.ofNullable(trigger.getMetadata().get("minimumConsumerRateMeasurements")).map(Long::parseLong).orElse(3L);
+        var consumerCommitTimeout = Optional.ofNullable(trigger.getMetadata().get("consumerCommitTimeout")).map(Duration::parse).orElseGet(() -> Duration.ofMinutes(1L));
 
         logger.debug("Requesting kafka metrics for topic={} and consumerGroupId={}", topic, consumerGroupId);
 
@@ -53,6 +54,7 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
         lagModel.setMinimumConsumerRateMeasurements(minimumConsumerRateMeasurements);
         lagModel.setTopicRatePercentile(topicRatePercentile);
         lagModel.setMinimumTopicRateMeasurements(minimumTopicRateMeasurements);
+        lagModel.setConsumerCommitTimeout(consumerCommitTimeout);
 
         var kafkaMetadata = KafkaMetadataCache.get(bootstrapServers);
         try {


### PR DESCRIPTION
…ently

At the moment we'll record new consumer offsets whenever `update` is called.  However our code will be being called every 10s and consumers may be configured to commit offsets a lot less frequently than that (minutes, maybe).

To avoid recording rates of zero in these cases, which could skew the stats, we skip over those offsets instead and only record them when they've changed, or if a configurable consumerCommitTimeout has passed