### PR TITLE
fix: default consumer rate to the final calculated target rate

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -65,14 +65,14 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
 
             var lag = lagModel.getLag();
             var targetRate = lagModel.getTopicRate().orElse(0);
-            var consumerRate = lagModel.estimateConsumerRate(replicaCount).orElse(targetRate);
+            var consumerRate = lagModel.estimateConsumerRate(replicaCount);
             if (lag > threshold) {
                 // We need to catch up, so calculate a target rate that will clear the lag within the SLA
                 var rateRequiredToClearLag = lag / (double) sla.toSeconds();
                 targetRate = targetRate + rateRequiredToClearLag;
             }
             // We need to invert the calculation because we need to scale _up_ to the target rate, not down
-            return TriggerResult.inverted(trigger, consumerRate, targetRate);
+            return TriggerResult.inverted(trigger, consumerRate.orElse(targetRate), targetRate);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);


### PR DESCRIPTION
..when the consumer rate isn't available yet we're using the initial target rate, not the rate after we've accounted for lag

This means that we'll scale up (maybe massively) on restart if there is lag on the topic, where we want to wait and see what happens to the rate instead