### PR TITLE
fix: allow different window size for the topic rates

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -37,9 +37,10 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
         var consumerGroupId = requireNonNull(trigger.getMetadata().get("consumerGroupId"));
         var threshold = Integer.parseInt(requireNonNull(trigger.getMetadata().get("threshold")));
         var sla = Duration.parse(Optional.ofNullable(trigger.getMetadata().get("sla")).orElse("PT10M"));
-        var windowSize = Optional.ofNullable(trigger.getMetadata().get("windowSize")).map(Integer::parseInt).orElse(360);
+        var topicRateWindowSize = Optional.ofNullable(trigger.getMetadata().get("topicRateWindowSize")).map(Integer::parseInt).orElse(90);
         var topicRatePercentile = Optional.ofNullable(trigger.getMetadata().get("topicRatePercentile")).map(Double::parseDouble).orElse(99D);
         var minimumTopicRateMeasurements = Optional.ofNullable(trigger.getMetadata().get("minimumTopicRateMeasurements")).map(Long::parseLong).orElse(3L);
+        var consumerWindowSize = Optional.ofNullable(trigger.getMetadata().get("consumerWindowSize")).map(Integer::parseInt).orElse(360);
         var consumerRatePercentile = Optional.ofNullable(trigger.getMetadata().get("consumerRatePercentile")).map(Double::parseDouble).orElse(99D);
         var minimumConsumerRateMeasurements = Optional.ofNullable(trigger.getMetadata().get("minimumConsumerRateMeasurements")).map(Long::parseLong).orElse(3L);
         var consumerCommitTimeout = Optional.ofNullable(trigger.getMetadata().get("consumerCommitTimeout")).map(Duration::parse).orElseGet(() -> Duration.ofMinutes(1L));
@@ -49,11 +50,14 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
         var lagModel = lagModelCache.get(new TopicConsumerGroupId(topic, consumerGroupId));
 
         // Update these values, in case the definition changed
-        lagModel.setWindowSize(windowSize);
+        lagModel.setConsumerRateWindowSize(consumerWindowSize);
         lagModel.setConsumerRatePercentile(consumerRatePercentile);
         lagModel.setMinimumConsumerRateMeasurements(minimumConsumerRateMeasurements);
+
+        lagModel.setTopicRateWindowSize(topicRateWindowSize);
         lagModel.setTopicRatePercentile(topicRatePercentile);
         lagModel.setMinimumTopicRateMeasurements(minimumTopicRateMeasurements);
+
         lagModel.setConsumerCommitTimeout(consumerCommitTimeout);
 
         var kafkaMetadata = KafkaMetadataCache.get(bootstrapServers);

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/TopicConsumerStats.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/TopicConsumerStats.java
@@ -51,12 +51,11 @@ public class TopicConsumerStats {
         this.historicalTopicRates.setWindowSize(360);
     }
 
-    public int getWindowSize() {
-        return this.historicalConsumerRates.getWindowSize();
+    public void setConsumerRateWindowSize(int windowSize) {
+        this.historicalConsumerRates.setWindowSize(windowSize);
     }
 
-    public void setWindowSize(int windowSize) {
-        this.historicalConsumerRates.setWindowSize(windowSize);
+    public void setTopicRateWindowSize(int windowSize) {
         this.historicalTopicRates.setWindowSize(windowSize);
     }
 


### PR DESCRIPTION
..and set a lower default.  The topic rate can be much more variable than the consumer rate, and needs to be responded to more quickly, so allow it to be set separately.

Also set the window to the equivalent of 15 minutes (90 * 10 seconds) by default