### PR TITLE
feat: allow consumer rate to be set as a constant on the kafka trigger

### DIFF
--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/KafkaLagTriggerProcessor.java
@@ -45,6 +45,7 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
         var consumerWindowSize = Optional.ofNullable(trigger.getMetadata().get("consumerWindowSize")).map(Integer::parseInt).orElse(360);
         var consumerRatePercentile = Optional.ofNullable(trigger.getMetadata().get("consumerRatePercentile")).map(Double::parseDouble).orElse(99D);
         var minimumConsumerRateMeasurements = Optional.ofNullable(trigger.getMetadata().get("minimumConsumerRateMeasurements")).map(Long::parseLong).orElse(3L);
+        var consumerMessagesPerSec = Optional.ofNullable(trigger.getMetadata().get("consumerMessagesPerSec")).map(Double::parseDouble).orElse(null);
         var consumerCommitTimeout = Optional.ofNullable(trigger.getMetadata().get("consumerCommitTimeout")).map(Duration::parse).orElseGet(() -> Duration.ofMinutes(1L));
 
         logger.debug("Requesting kafka metrics for topic={} and consumerGroupId={}", topic, consumerGroupId);
@@ -60,6 +61,7 @@ public class KafkaLagTriggerProcessor implements TriggerProcessor {
         lagModel.setTopicRatePercentile(topicRatePercentile);
         lagModel.setMinimumTopicRateMeasurements(minimumTopicRateMeasurements);
 
+        lagModel.setConsumerMessagesPerSec(consumerMessagesPerSec);
         lagModel.setConsumerCommitTimeout(consumerCommitTimeout);
 
         var kafkaMetadata = KafkaMetadataCache.get(bootstrapServers);

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/TopicConsumerStats.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/triggers/kafka/TopicConsumerStats.java
@@ -16,7 +16,9 @@ import io.micrometer.core.instrument.Tags;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class TopicConsumerStats {
     private final LongSupplier clock;
 
@@ -32,6 +34,9 @@ public class TopicConsumerStats {
     @Getter
     @Setter
     private long minimumConsumerRateMeasurements = 3;
+    @Getter
+    @Setter
+    private Double consumerMessagesPerSec = null;
     @Getter
     @Setter
     private double topicRatePercentile = 99D;
@@ -113,6 +118,9 @@ public class TopicConsumerStats {
     }
 
     public OptionalDouble estimateConsumerRate(int replicaCount) {
+        if (consumerMessagesPerSec != null) {
+            return OptionalDouble.of(consumerMessagesPerSec * replicaCount);
+        }
         if (historicalConsumerRates.getN() < minimumConsumerRateMeasurements) {
             return OptionalDouble.empty();
         }


### PR DESCRIPTION
For when the rate detection doesn't work well (which it doesn't), we can just have the user set a constant rate that we use instead

We still have metrics to allow us to tell whether this is set correctly