### PR TITLE
feat: support min and max replica counts on spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ metadata:
 spec:
   dryRun: false # set true to see what the autoscaler _would_ do
   cooloffSeconds: 300
-  maxScaleIncrements: 1
+  maxScaleIncrements: 1 # how many increments to scale by, increment of 1 will allow scaling from 1->2, 2->4, 4->8 
+                        #2 will allow 1->4 but not 1->8 
+  minReplicas: 1        # optional
+  maxReplicas: 16       # optional: partition count will be used if missing 
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
+++ b/kustomize/crd/kafkapodautoscaler.brandwatch.com-v1alpha1.yaml
@@ -78,6 +78,10 @@ spec:
                       type: object
                   type: object
                 type: array
+              minReplicas:
+                type: integer
+              maxReplicas:
+                type: integer
               maxScaleIncrements:
                 type: integer
             required:

--- a/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/KafkaPodAutoscalerSpec.java
+++ b/src/main/java/com/brandwatch/kafka_pod_autoscaler/v1alpha1/KafkaPodAutoscalerSpec.java
@@ -57,6 +57,16 @@ public class KafkaPodAutoscalerSpec implements KubernetesResource {
     private List<TriggerDefinition> triggers = Serialization.unmarshal("[]", List.class);
     @Getter
     @Setter
+    @JsonProperty("minReplicas")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Integer minReplicas = null;
+    @Getter
+    @Setter
+    @JsonProperty("maxReplicas")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Integer maxReplicas = null;
+    @Getter
+    @Setter
     @JsonProperty("maxScaleIncrements")
     @JsonSetter(nulls = Nulls.SKIP)
     private int maxScaleIncrements = 1;


### PR DESCRIPTION
At the moment the autoscaler will scale down to 1 and up to however many partitions are on the topic

This change allows the min/max number of replicas to be set on the autoscaler itself